### PR TITLE
Prevent scrollbar from repositioning page

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -144,6 +144,11 @@
   max-width: 100%;
 }
 
+/* https://stackoverflow.com/questions/1417934/how-to-prevent-scrollbar-from-repositioning-web-page */
+html {
+  padding-left: calc(100vw - 100%);
+}
+
 @layer base {
   body {
     @apply text-base;


### PR DESCRIPTION
When navigating between a page that has a scrollbar, and a page that doesn't, the positioning of all elements was jumping in order to reclaim the space the scrollbar had taken up.

Used an answer from https://stackoverflow.com/questions/1417934/how-to-prevent-scrollbar-from-repositioning-web-page

### Before

https://user-images.githubusercontent.com/60350599/198015497-7008d3b3-0080-4bf0-9b93-966e111a13a7.mov

### After

https://user-images.githubusercontent.com/60350599/198015540-840d4877-28cb-46e2-b6c3-c4f140015c61.mov