### PR TITLE
Fix active tabs navbar

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -20,10 +20,9 @@ import { NavbarSimple } from './navbar'
 
 type LayoutProps = {
   children: React.ReactNode
-  activeTab: string
 }
 
-export function Layout({ children, activeTab }: LayoutProps) {
+export function Layout({ children }: LayoutProps) {
   const { data: session } = useSession()
   const [isSearchDialogOpen, setIsSearchDialogOpen] = React.useState(false)
   {
@@ -32,7 +31,7 @@ export function Layout({ children, activeTab }: LayoutProps) {
 
   return (
     <div className="flex relative max-w-7xl m-auto">
-      <NavbarSimple activeTab={activeTab}></NavbarSimple>
+      <NavbarSimple></NavbarSimple>
       <div className="px-6 w-full mx-auto flex flex-col min-h-screen">
         <header className="flex items-center justify-end mt-6 mb-6 pt-4 gap-4 h-16">
           <div className="flex items-center gap-2 md:gap-4">

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -97,19 +97,19 @@ const data = [
   { link: '/page/support', label: 'Help & support', icon: LifebuoyIcon },
 ]
 
-export function NavbarSimple({ activeTab }: { activeTab: string }) {
+export function NavbarSimple() {
   const { classes, cx } = useStyles()
   const router = useRouter()
 
   const links = data.map((item) => (
-    <Link
-      className={cx(classes.link, {
-        [classes.linkActive]: item.link === router.pathname,
-      })}
-      href={item.link}
-      key={item.label}
-    >
-      <div className="flex my-5 text-sm items-center cursor-pointer">
+    <Link href={item.link} key={item.label}>
+      <div
+        className={
+          cx(classes.link, {
+            [classes.linkActive]: item.link === router.pathname,
+          }) + ' flex my-5 text-sm items-center cursor-pointer'
+        }
+      >
         <item.icon className={classes.linkIcon} />
         <span>{item.label}</span>
       </div>

--- a/pages/certificate/[id]/edit.tsx
+++ b/pages/certificate/[id]/edit.tsx
@@ -121,7 +121,7 @@ const EditCertificatePage: NextPageWithAuthAndLayout = () => {
 EditCertificatePage.auth = true
 
 EditCertificatePage.getLayout = function getLayout(page: React.ReactElement) {
-  return <Layout activeTab="Home">{page}</Layout>
+  return <Layout>{page}</Layout>
 }
 
 export default EditCertificatePage

--- a/pages/certificate/[id]/index.tsx
+++ b/pages/certificate/[id]/index.tsx
@@ -232,7 +232,7 @@ const CertificatePage: NextPageWithAuthAndLayout = () => {
 CertificatePage.auth = true
 
 CertificatePage.getLayout = function getLayout(page: React.ReactElement) {
-  return <Layout activeTab="Home">{page}</Layout>
+  return <Layout>{page}</Layout>
 }
 
 export default CertificatePage

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -162,7 +162,7 @@ const Home: NextPageWithAuthAndLayout = () => {
 Home.auth = true
 
 Home.getLayout = function getLayout(page: React.ReactElement) {
-  return <Layout activeTab="Home">{page}</Layout>
+  return <Layout>{page}</Layout>
 }
 
 export default Home

--- a/pages/new.tsx
+++ b/pages/new.tsx
@@ -75,7 +75,7 @@ const NewCertificatePage: NextPageWithAuthAndLayout = () => {
 NewCertificatePage.auth = true
 
 NewCertificatePage.getLayout = function getLayout(page: React.ReactElement) {
-  return <Layout activeTab="Home">{page}</Layout>
+  return <Layout>{page}</Layout>
 }
 
 export default NewCertificatePage

--- a/pages/page/funders.tsx
+++ b/pages/page/funders.tsx
@@ -21,7 +21,7 @@ const FundersAndPrizesPage: NextPageWithAuthAndLayout = () => {
 FundersAndPrizesPage.auth = true
 
 FundersAndPrizesPage.getLayout = function getLayout(page: React.ReactElement) {
-  return <Layout activeTab="Funders & prizes">{page}</Layout>
+  return <Layout>{page}</Layout>
 }
 
 export default FundersAndPrizesPage

--- a/pages/page/rules.tsx
+++ b/pages/page/rules.tsx
@@ -21,7 +21,7 @@ const RulesAndTerms: NextPageWithAuthAndLayout = () => {
 RulesAndTerms.auth = true
 
 RulesAndTerms.getLayout = function getLayout(page: React.ReactElement) {
-  return <Layout activeTab="Rules & terms">{page}</Layout>
+  return <Layout>{page}</Layout>
 }
 
 export default RulesAndTerms

--- a/pages/page/support.tsx
+++ b/pages/page/support.tsx
@@ -31,7 +31,7 @@ const HelpAndSupportPage: NextPageWithAuthAndLayout = () => {
 HelpAndSupportPage.auth = true
 
 HelpAndSupportPage.getLayout = function getLayout(page: React.ReactElement) {
-  return <Layout activeTab="Help & support">{page}</Layout>
+  return <Layout>{page}</Layout>
 }
 
 export default HelpAndSupportPage

--- a/pages/page/why.tsx
+++ b/pages/page/why.tsx
@@ -21,7 +21,7 @@ const WhyImpactMarkets: NextPageWithAuthAndLayout = () => {
 WhyImpactMarkets.auth = true
 
 WhyImpactMarkets.getLayout = function getLayout(page: React.ReactElement) {
-  return <Layout activeTab="Why impact markets?">{page}</Layout>
+  return <Layout>{page}</Layout>
 }
 
 export default WhyImpactMarkets

--- a/pages/profile/[userId].tsx
+++ b/pages/profile/[userId].tsx
@@ -82,7 +82,7 @@ const ProfilePage: NextPageWithAuthAndLayout = () => {
 ProfilePage.auth = true
 
 ProfilePage.getLayout = function getLayout(page: React.ReactElement) {
-  return <Layout activeTab="Home">{page}</Layout>
+  return <Layout>{page}</Layout>
 }
 
 function ProfileInfo({ user }: ProfileComponentProps) {


### PR DESCRIPTION
For whatever reason, the `Link` component was not respecting the `className` attribute, so I moved it onto the div.

Note that we don't need to manually hard-code the active tab on each page, now that we are using the `router.pathName` lookup which dynamically checks which tab should be active. So the `activeTab` parameter has been removed.

<img width="1440" alt="Screenshot 2022-10-26 at 14 36 23" src="https://user-images.githubusercontent.com/60350599/198040408-4b0bd2fa-d593-4bfa-bce0-afcda506656f.png">
