### PR TITLE
Remove unused code

### DIFF
--- a/server/routers/certificate.ts
+++ b/server/routers/certificate.ts
@@ -235,16 +235,7 @@ export const certificateRouter = createProtectedRouter()
         })
       }
 
-      // Set the `issuerEmails` using the associated certificateIssuers
-      const issuerEmails = certificate.issuers
-        .map((issuer) => issuer.user.email)
-        .filter((x) => x)
-        .join(',')
-
-      return {
-        issuerEmails,
-        ...certificate,
-      }
+      return certificate
     },
   })
   .query('search', {


### PR DESCRIPTION
Micro-PR: not sure if this happened as a result of merging conflicts. As far as I know, there was no reason to add `issuerEmails` to the return value, as it's not used.

Maybe you added this intentionally for future use, in which case please close this PR.