### PR TITLE
Only show reply button if logged in

### DIFF
--- a/components/project/comment.tsx
+++ b/components/project/comment.tsx
@@ -87,7 +87,7 @@ export function Comment({
       <div className="mt-4 pl-11 sm:pl-16">
         <HtmlView html={comment.contentHtml} />
 
-        {!comment.parent && !isReplying && (
+        {session && !comment.parent && !isReplying && (
           <div className="text-secondary hover:text-blue text-sm">
             <button
               type="submit"


### PR DESCRIPTION
I saw in the staging build that there are reply buttons on comments even when I'm not logged in (although clicking them does nothing).