### PR TITLE
[#76] make default sorting clear

### DIFF
--- a/pages/bounties.tsx
+++ b/pages/bounties.tsx
@@ -20,9 +20,9 @@ const Summary = dynamic<SummaryProps>(
 )
 
 const orderByValues: Array<{ value: BountySortKey; label: string }> = [
-  { value: 'createdAt', label: 'Creation date' },
-  { value: 'deadline', label: 'Deadline' },
-  { value: 'size', label: 'Bounty amount' },
+  { value: 'createdAt', label: 'Sort by creation date' },
+  { value: 'deadline', label: 'Sort by deadline' },
+  { value: 'size', label: 'Sort by bounty amount' },
 ]
 
 const defaultOrder = 'size'

--- a/pages/certificates.tsx
+++ b/pages/certificates.tsx
@@ -24,10 +24,10 @@ const CertificateSummary = dynamic<CertificateSummaryProps>(
 )
 
 const orderByValues: Array<{ value: ProjectSortKey; label: string }> = [
-  { value: 'createdAt', label: 'Creation date' },
-  { value: 'actionStart', label: 'Start of work' },
-  { value: 'actionEnd', label: 'End of work' },
-  { value: 'supporterCount', label: 'Supporters' },
+  { value: 'createdAt', label: 'Sort by creation date' },
+  { value: 'actionStart', label: 'Sort by start of work' },
+  { value: 'actionEnd', label: 'Sort by end of work' },
+  { value: 'supporterCount', label: 'Sort by supporters' },
 ]
 
 const defaultOrder = 'supporterCount'

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -21,10 +21,10 @@ const ProjectSummary = dynamic<ProjectSummaryProps>(
 )
 
 const orderByValues: Array<{ value: ProjectSortKey; label: string }> = [
-  { value: 'createdAt', label: 'Creation date' },
-  { value: 'actionStart', label: 'Start of work' },
-  { value: 'actionEnd', label: 'End of work' },
-  { value: 'supporterCount', label: 'Supporters' },
+  { value: 'createdAt', label: 'Sort by creation date' },
+  { value: 'actionStart', label: 'Sort by start of work' },
+  { value: 'actionEnd', label: 'Sort by end of work' },
+  { value: 'supporterCount', label: 'Sort by supporters' },
 ]
 
 const defaultOrder = 'supporterCount'


### PR DESCRIPTION
added default sorting ("Creation date") to "Sort by:" placeholder"

(would it be better to do this with a variable in case we change the default sorting, or in case default sorting ends up being different for bounties vs projects?)